### PR TITLE
feat: Load years for dropdown from API

### DIFF
--- a/src/components/MapaCeara.jsx
+++ b/src/components/MapaCeara.jsx
@@ -69,9 +69,19 @@ const MapaCeara = () => {
   const [anoFinal, setAnoFinal] = useState(new Date().getFullYear());
   const [cursosSelecionados, setCursosSelecionados] = useState(['Todos']);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [anosDisponiveis, setAnosDisponiveis] = useState([]);
 
-  const anosDisponiveis = Array.from({ length: 16 }, (_, i) => 2010 + i);
   const opcoesCursos = ['Informática', 'Administração', 'Enfermagem'];
+
+  useEffect(() => {
+    fetch('https://web-production-3163.up.railway.app/years_suap')
+      .then(res => res.json())
+      .then(data => {
+        const years = data.map(item => item.ano);
+        setAnosDisponiveis(years);
+      })
+      .catch(err => console.error('Erro ao carregar anos:', err));
+  }, []);
 
   const handleCursoCheckboxChange = (curso) => {
     if (curso === 'Todos') {


### PR DESCRIPTION
- I've modified `MapaCeara.jsx` to fetch the available years for the `anoInicial` and `anoFinal` dropdowns from the `https://web-production-3163.up.railway.app/years_suap` API endpoint.
- This replaces the previously hardcoded list of years, making the component more dynamic and data-driven.